### PR TITLE
Remove incorrect use of width and height

### DIFF
--- a/as3lib/__init__.py
+++ b/as3lib/__init__.py
@@ -52,11 +52,7 @@ def sm_x11():
    for i in check_output(('xwininfo', '-root')).decode('utf-8').split('\n'):
       if 'Depth' in i:
          depth = int(i.split(':')[1].strip())
-      if 'Width' in i:
-         width = int(i.split(':')[1].strip())
-      if 'Height' in i:
-         height = int(i.split(':')[1].strip())
-   return width, height, rr, depth
+   return rr, depth
 
 
 def sm_wayland():
@@ -64,29 +60,26 @@ def sm_wayland():
 
 
 def sm_windows():
-   import ctypes
-   width = int(ctypes.windll.user32.GetSystemMetrics(0))
-   height = int(ctypes.windll.user32.GetSystemMetrics(1))
    try:
       import win32api
    except ModuleNotFoundError:
       print('Warning: Windows requirement "pywin32" not found. Using default screen parameters.')
-      return width, height, 60.0, 16
+      return 60.0, 16
    settings = win32api.EnumDisplaySettings(win32api.EnumDisplayDevices().DeviceName, -1)
-   return width, height, float(getattr(settings, 'DisplayFrequency')), int(getattr(settings, 'BitsPerPel'))
+   return float(getattr(settings, 'DisplayFrequency')), int(getattr(settings, 'BitsPerPel'))
 
 
 def sm_darwin():
    as3state.initerror.append('Platform/Darwin: Fetching screen properties is not implemented.')
-   return 1600, 900, 60.0, 16  # Placeholder
+   return 60.0, 16  # Placeholder
 
 
 def setScreenProperties(func):
    try:
       temp = func()
    except:
-      temp = (1600, 900, 60.0, 16)
-   as3state.width, as3state.height, as3state.refreshrate, as3state.colordepth = temp
+      temp = (60.0, 16)
+   as3state.refreshrate, as3state.colordepth = temp
 
 
 # Initialise as3lib
@@ -129,7 +122,7 @@ if not as3state.initdone:
 
    # Ensure that at least something is loaded if values fail to load
    # This is a fix for the case where platform is not valid AND the display config values are missing
-   if None in {as3state.width, as3state.height, as3state.refreshrate, as3state.colordepth}:
+   if None in {as3state.refreshrate, as3state.colordepth}:
       setScreenProperties(None)
 
    # Load the config

--- a/as3lib/as3state.py
+++ b/as3lib/as3state.py
@@ -21,8 +21,6 @@ MaxWarnings = 100  # Number of warnings to log before stopping.
 TraceOutputFileEnable = False  # Enables trace logging (console output is always be active in the debugger)
 TraceOutputFileName = None  # Path to the log
 ClearLogsOnStartup = True  # If True, clears logs on startup. This is the default behavior in flash
-width = None  # Maximum width of the display window (not implemented yet)
-height = None  # Maximum height of the display window (not implemented yet)
 refreshrate = None  # Refresh rate of the display window (not implemented yet)
 colordepth = None  # Color depth of the display window (not implemented yet)
 

--- a/as3lib/config.py
+++ b/as3lib/config.py
@@ -140,8 +140,6 @@ def Load():
             'NoClearWarningNumber': int(tempmm.get('NoClearWarningNumber', 0))
          },
          'display': {
-            'screenwidth': int(tempdis.get('screenwidth', 0)),
-            'screenheight': int(tempdis.get('screenheight', 0)),
             'refreshrate': float(tempdis.get('refreshrate', 0)),
             'colordepth': int(tempdis.get('colordepth', 0))
          }
@@ -162,8 +160,6 @@ def Load():
             'NoClearWarningNumber': 0
          },
          'display': {
-            'screenwidth': 0,
-            'screenheight': 0,
             'refreshrate': 0,
             'colordepth': 0
          }
@@ -205,8 +201,6 @@ def Load():
          with open(wlcfgpath, 'r') as f:
             wlcfg.read_file(f)
          cfg['display'] = {
-            'screenwidth': wlcfg.getint('Screen', 'screenwidth', fallback=0),
-            'screenheight': wlcfg.getint('Screen', 'screenheight', fallback=0),
             'refreshrate': wlcfg.getfloat('Screen', 'refreshrate', fallback=0),
             'colordepth': wlcfg.getint('Screen', 'colordepth', fallback=0)
          }
@@ -231,8 +225,6 @@ def Load():
                'NoClearWarningNumber': oldcfg.getint('mm.cfg', 'NoClearWarningNumber', fallback=0)
             },
             'display': {
-               'screenwidth': oldcfg.getint('wayland', 'screenwidth', fallback=0),
-               'screenheight': oldcfg.getint('wayland', 'screenheight', fallback=0),
                'refreshrate': oldcfg.getfloat('wayland', 'refreshrate', fallback=0),
                'colordepth': oldcfg.getint('wayland', 'colordepth', fallback=0)
             }
@@ -257,10 +249,6 @@ def Load():
       tempTraceOutputFileName = as3state.librarydirectory / 'flashlog.txt'
    as3state.TraceOutputFileName = Path(tempTraceOutputFileName)
    tmpd = cfg['display']
-   if tmpd['screenwidth']:
-      as3state.width = tmpd['screenwidth']
-   if tmpd['screenheight']:
-      as3state.height = tmpd['screenheight']
    if tmpd['refreshrate']:
       as3state.refreshrate = tmpd['refreshrate']
    if tmpd['colordepth']:
@@ -284,8 +272,6 @@ def Save(saveAnyways: bool = False):
          'NoClearWarningNumber': 0 if as3state.ClearLogsOnStartup else as3state.CurrentWarnings
       },
       'display': {
-         'screenwidth': as3state.width,
-         'screenheight': as3state.height,
          'refreshrate': as3state.refreshrate,
          'colordepth': as3state.colordepth
       }

--- a/as3lib/flash/system.py
+++ b/as3lib/flash/system.py
@@ -91,11 +91,13 @@ class Capabilities:
 
    @property
    def screenResolutionX():
-      return as3state.width
+      # Initial width of the display frame
+      return NotImplementedError
 
    @property
    def screenResolutionY():
-      return as3state.height
+      # Initial height of the display frame
+      return NotImplementedError
 
    #serverString
    #supports32BitProcesses

--- a/as3lib/interface_tk.py
+++ b/as3lib/interface_tk.py
@@ -915,6 +915,7 @@ class itkRoot(tkinter.Toplevel):
       tkinter.Tk window.
    '''
    def __init__(self, **kwargs):
+      # TODO: Set max/min size
       self._id = next(_windowID)
       self._startwidth = kwargs.pop('defaultWidth', kwargs.pop('width'))
       self._startheight = kwargs.pop('defaultHeight', kwargs.pop('height'))
@@ -934,8 +935,7 @@ class itkRoot(tkinter.Toplevel):
       self._fontmult = 100
       self.geometry(f'{self._startwidth}x{self._startheight}')
       self.title(self._title)
-      if as3state.width not in {-1, None} and as3state.height not in {-1, None}:
-         self.maxsize(as3state.width, as3state.height)
+      #self.maxsize(<width>, <height>)
       self.bind('<Configure>', self.doResize)
       self.bind('<Escape>', self.outfullscreen)
       self.icon = ico


### PR DESCRIPTION
I interpreted the documentation wrong. screenResolutionX and screenResolutionY are supposed to be the initial viewport dimensions, not the connected physical output's resolution